### PR TITLE
Fixes link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 
 Nodeconf London is a one day single track speaker series.
 
-To register your interest, visit [london.nodeconf.com](london.nodeconf.com)
+To register your interest, visit [london.nodeconf.com](http://london.nodeconf.com)


### PR DESCRIPTION
Current link tried to redirect to https://github.com/nodeconf/london/blob/master/london.nodeconf.com.
